### PR TITLE
feat(profiler): add minimal FPS overlay with exclusive display mode

### DIFF
--- a/shove.lua
+++ b/shove.lua
@@ -572,11 +572,6 @@ local function compositeLayersOnScreen(globalEffects, applyPersistentEffects)
     return false
   end
 
-  -- Reset batch metrics
-  state.specialLayerUsage.batchGroups = 0
-  state.specialLayerUsage.batchedLayers = 0
-  state.specialLayerUsage.stateChanges = 0
-
   -- Ensure we have a composite layer
   if not state.layers.composite then
     createCompositeLayer()


### PR DESCRIPTION
# Description

- Add new minimal FPS overlay that shows only FPS and frame time
- Implement mutual exclusivity between full profiler and FPS overlay
- Add keyboard shortcut (Ctrl+T) to toggle FPS overlay
- Add gamepad support (Select+X) when main overlay is not visible
- Add touch support (triple tap in top-right corner)
- Ensure VSync toggle works with either overlay visible
- Use larger font with outline for better visibility

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections