### PR TITLE
fix(rendering): prevent mask layers from being composited

### DIFF
--- a/shove-profiler.lua
+++ b/shove-profiler.lua
@@ -456,7 +456,8 @@ local function renderLayerInfo(renderX, renderY)
         color = shoveProfiler.config.colors.red
       elseif layer.name == state.layers.active then
         color = shoveProfiler.config.colors.green
-      elseif not layer.hasCanvas then
+      elseif not layer.hasCanvas or layer.isUsedAsMask then
+        -- Show mask layers in gray to indicate they're not composited
         color = shoveProfiler.config.colors.midGray
       end
 


### PR DESCRIPTION
The mask demo was failing intermittently after batch processing was added because mask layers were incorrectly included in the final composite.

This change:

- Adds an isUsedAsMask flag to track layers that are used as masks
- Updates mask layer signatures to prevent batching with regular layers
- Excludes mask layers from both batch and traditional rendering paths

The mask demo now works consistently.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections