### PR TITLE
feat: add canvas proxy demo

### DIFF
--- a/demo/canvas-proxy/init.lua
+++ b/demo/canvas-proxy/init.lua
@@ -1,0 +1,45 @@
+return function()
+  local userCanvas = nil
+  function love.load()
+    local windowWidth, windowHeight = love.window.getDesktopDimensions()
+    shove.setResolution(800, 600, { fitMethod = "none", renderMode = "direct" })
+    shove.setWindowMode(windowWidth * 0.5, windowHeight * 0.5, { fullscreen = false, resizable = true })
+    userCanvas = love.graphics.newCanvas(200, 200)
+  end
+
+  function love.draw()
+    -- Clear background
+    love.graphics.clear(0.1, 0.1, 0.3)
+    -- Begin Shöve's drawing context
+    shove.beginDraw()
+      -- Draw a red circle in the Shöve managed area
+      love.graphics.setColor(1, 0, 0)
+      love.graphics.circle("fill", 200, 150, 100)
+
+      -- User manually changes canvas during Shöve's drawing cycle
+      love.graphics.setCanvas(userCanvas)
+      love.graphics.clear(0, 0, 0, 0)
+      love.graphics.setColor(0, 1, 0)
+      love.graphics.rectangle("fill", 50, 50, 100, 100)
+      love.graphics.setCanvas() -- Reset to default
+
+      -- This blue circle should now appear properly with our fix
+      -- since the canvas state is properly restored
+      love.graphics.setColor(0, 0, 1)
+      love.graphics.circle("fill", 200, 150, 50)
+
+    -- End Shöve's drawing context
+    shove.endDraw()
+
+    -- Draw the user's canvas to screen directly (outside Shöve)
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.draw(userCanvas, 580, 10)
+
+    -- Display explanation
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.print("Red circle: Initial Shöve drawing", 10, 310)
+    love.graphics.print("Green square: Rendered to user canvas", 10, 330)
+    love.graphics.print("Blue circle: After canvas reset", 10, 350)
+    love.graphics.print("User canvas result -->", 580, 350)
+  end
+end

--- a/demo/main.lua
+++ b/demo/main.lua
@@ -9,6 +9,7 @@ local demo_data = {
   { module = "multiple-shaders" },
   { module = "mouse-input" },
   { module = "canvases-shaders" },
+  { module = "canvas-proxy" },
   { module = "stencil" },
   { module = "mask" },
   { module = "parallax" },


### PR DESCRIPTION
Adds a new demo showcasing canvas proxy functionality. The demo renders to a user-managed canvas within the Shove drawing cycle, demonstrating proper canvas state restoration.
