### PR TITLE
refactor(rendering): make sharedEffectsTable local to compositeLayersOnScreen

### DIFF
--- a/shove.lua
+++ b/shove.lua
@@ -101,8 +101,6 @@ local function createMaskShader()
   ]]
 end
 
--- Persistent tables for reuse to minimize allocations
-local sharedEffectsTable = {}
 -- Canvas pools
 local canvasPools = {
   standard = {},
@@ -588,10 +586,8 @@ local function compositeLayersOnScreen(globalEffects, applyPersistentEffects)
   love.graphics.push()
   love.graphics.scale(state.scale_x, state.scale_y)
 
-  -- Clear shared effects table instead of creating a new one
-  for k in pairs(sharedEffectsTable) do
-    sharedEffectsTable[k] = nil
-  end
+  -- Create shared effects
+  local sharedEffectsTable = {}
 
   -- Only apply persistent global effects when requested
   if applyPersistentEffects then


### PR DESCRIPTION
The sharedEffectsTable variable is only used within the compositeLayersOnScreen function, so converting it from module-level to function-local scope improves code organization and reduces global state. This change:

- Reduces state management complexity by localizing the variable
- Prevents potential state leakage between render calls
- Makes the code's intent clearer by placing variable declaration where it's used

This is a low-risk change that maintains identical functionality while making
the code more maintainable.
