### PR TITLE
Fix for functions that uses getPosition globally

### DIFF
--- a/shove.lua
+++ b/shove.lua
@@ -1656,7 +1656,7 @@ local shove = {
   ---@return number mouseX Viewport X coordinate
   ---@return number mouseY Viewport Y coordinate
   mouseToViewport = function()
-    local mouseX, mouseY = love.mouse.getPosition()
+    local mouseX, mouseY = love.mouse.getX(), love.mouse.getY()
     return shove.screenToViewport(mouseX, mouseY)
   end,
 


### PR DESCRIPTION
# Description

So, recently I started using Shove for my game editor, when creating the interface with loveframes, I notice that when I resize the window, I can't no longer use the buttons, so I made a simple change on one of the functions and worked.
This fix make the `love.mouse.getPosition` easily overridable without causing stack overflow, Shove use this function internally, and made impossible to override and made other libraries that use this function (eg: UI Libraries) to work with Shove out of the box.

- Resolves: Any library that uses the `love.mouse.getPosition` function now can safely be overrided without causing stack overflow.

Example:
```lua
love.mouse.getPosition = function ()
        local inside, mx, my = shove.mouseToViewport()
        return mx, my
end
```

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [ X ] I have performed a self-review of my code
- [ X ] I have tested my code in common scenarios and confirmed there are no regressions
